### PR TITLE
ci: remove version from docker-compose since it is depricated

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 ---
-version: "3.7"
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     image: docker.io/library/alpine:3.21
     networks:
       - opi
+    command: |
+      sh -c 'sleep 20 && exit 0'
 
 networks:
   opi:


### PR DESCRIPTION
Finish setup of opi-mangoboost-bridge repository for new contributions from vendor per request of TSC and vendor.