### PR TITLE
test: fix a docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,94 @@
 
 services:
 
-  opi-test:
-    image: docker.io/library/alpine:3.21
+  opi-mangoboost-server:
+    build:
+      context: .
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+    ports:
+      - "8082:8082"
+      - "50051:50051"
     networks:
       - opi
-    command: |
-      sh -c 'sleep 20 && exit 0'
+    volumes:
+      - /var/tmp:/var/tmp
+    depends_on:
+      redis:
+        condition: service_healthy
+      jaeger:
+        condition: service_healthy
+    command: /opi-mangoboost-bridge -grpc_port=50051 -http_port=8082 -spdk_addr /var/tmp/spdk.sock -redis_addr=redis:6379
+    healthcheck:
+      test: grpcurl -plaintext localhost:50051 list || exit 1
+
+  redis:
+    image: redis:7.2.3-alpine3.18
+    networks:
+      - opi
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.53.0
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    networks:
+      - opi
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "nc -zv localhost 4317 && nc -zv localhost 4318 || exit 1"
+        ]
+      interval: 6s
+      retries: 5
+      start_period: 20s
+      timeout: 10s
+
+  opi-gw-test:
+    image: curlimages/curl:8.5.0
+    networks:
+      - opi
+    depends_on:
+      opi-mangoboost-server:
+        condition: service_healthy
+    command: curl -qkL http://opi-mangoboost-server:8082/v1/inventory/1/inventory/2
+
+  opi-jaeger-test:
+    image: curlimages/curl:8.5.0
+    networks:
+      - opi
+    depends_on:
+      opi-mangoboost-server:
+        condition: service_healthy
+      opi-gw-test:
+        condition: service_completed_successfully # to get at least one operation registered in jaeger
+    command: sh -c 'curl -s "http://jaeger:16686/api/traces?service=opi-mangoboost-bridge&lookback=20m&prettyPrint=true&limit=10" | grep operationName'
+
+  opi-test:
+    image: docker.io/namely/grpc-cli
+    networks:
+      - opi
+    depends_on:
+      opi-gw-test:
+        condition: service_completed_successfully
+      opi-jaeger-test:
+        condition: service_completed_successfully
+    command: ls opi-mangoboost-server:50051 opi_api.storage.v1.FrontendNvmeService -l
+
+  opi-client:
+    image: docker.io/opiproject/godpu:main
+    networks:
+      - opi
+    depends_on:
+      opi-mangoboost-server:
+        condition: service_healthy
+    command: storage test --addr=opi-mangoboost-server:50051
 
 networks:
   opi:


### PR DESCRIPTION
This patch fixes the docker compose file to run and test docker images for the mangoboost bridge.