### PR TITLE
fix(lint): migrate .golangci.yml to v2 schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,4 @@
-# This file contains all available configuration options
-# with their default values.
-
-# options for analysis running
-run:
-
-# output configuration options
-output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  formats: colored-line-number
-
-linters-settings:
-  funlen:
-    lines: 120
-    statements: 120
-  dupl:
-    threshold: 200
-  gocognit:
-    min-complexity: 32
+version: "2"
 
 linters:
   enable:
@@ -29,10 +11,7 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -40,27 +19,30 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
     - unconvert
     - unparam
     - whitespace
+  settings:
+    funlen:
+      lines: 120
+      statements: 120
+    dupl:
+      threshold: 200
+    gocognit:
+      min-complexity: 32
+  exclusions:
+    rules:
+      - path: (.+)_test.go
+        linters:
+          - funlen
+          - gocritic
+          - gocognit
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
 
 issues:
-  # Independently from option `exclude` we use default exclude patterns,
-  # it can be disabled by this option. To list all
-  # excluded by default patterns execute `golangci-lint run --help`.
-  # Default value for this option is true.
-  exclude-use-default: false
-
-  exclude-rules:
-    - path: (.+)_test.go
-      linters:
-        - funlen
-        - gocritic
-        - gocognit
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,8 @@ services:
         condition: service_completed_successfully
       opi-jaeger-test:
         condition: service_completed_successfully
-    command: ls opi-mangoboost-server:50051 opi_api.storage.v1.FrontendNvmeService -l
+    entrypoint: ["sh", "-c"]
+    command: ["grpc_cli ls opi-mangoboost-server:50051 opi_api.storage.v1.FrontendNvmeService -l; rc=$?; sleep 5; exit $rc"]
 
   opi-client:
     image: docker.io/opiproject/godpu:main


### PR DESCRIPTION
golangci-lint-action@v8 now installs golangci-lint v2.x, which rejects the v1 config with errors.

Migrate the config to v2 format:
  - Add version: "2" header
  - Drop the v1 output.formats stanza (default rendering is fine)
  - Move funlen/dupl/gocognit under linters.settings
  - Move _test.go exclusions under linters.exclusions.rules
  - Move gofmt/goimports to the formatters section
  - Drop gosimple and stylecheck (merged into staticcheck in v2)